### PR TITLE
Update Python version requirement to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "huami_token"
 version = "0.8.0"
 description = "This script retrieves the Bluetooth access token for the watch or band from Huami servers. Additionally, it downloads the AGPS data packs, cep_alm_pak.zip and cep_7days.zip."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
   { name = "Kirill Snezhko", email = "kirill.snezhko@pm.me" },
 ]


### PR DESCRIPTION
Update the minimum Python version requirement from 3.8 to 3.10 to enable the use of modern Python features, particularly the match/case statement in [src/cli.py](https://github.com/argrento/huami-token/blob/82b7a4c6209a684d167be83df46a57365b4796cf/src/cli.py#L67) in Python 3.10