### PR TITLE
Update installation command for package

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ with e-mail and password.
 Huami servers.
 3. Install `uv`: https://docs.astral.sh/uv/getting-started/installation/
 4. Clone this repo and `cd` into it.
-5. Install the package: `uv pip install -e ".[dev]"`
+5. Install the package: `uv pip install -e ".[dev] --system"`
+6. Add the huami-token executable to the environment `pyenv rehash`
 
 ## Usage
 


### PR DESCRIPTION
The installation from source commands did not work as advertised for me. These are the fixes

```
HarvsG@Desktop:~/repos/huami-token$ uv pip install -e ".[dev]"
error: No virtual environment found; run `uv venv` to create an environment, or pass `--system` to install into a non-virtual environment

HarvsG@Desktop:~/repos/huami-token$ uv pip install -e ".[dev]" --system
Using Python 3.11.8 environment at: /home/george/.pyenv/versions/3.11.8
Resolved 20 packages in 379ms
      Built huami-token @ file:///home/george/repos/huami-token
      
HarvsG@Desktop:~/repos/huami-token$ huami-token
huami-token: command not found
HarvsG@Desktop:~/repos/huami-token$ pyenv rehash
HarvsG@Desktop:~/repos/huami-token$ huami-token
usage: huami-token [-h] -m {amazfit,xiaomi} [-e EMAIL] [-p PASSWORD] [-b] [-g] [-n]
huami-token: error: the following arguments are required: -m/--method
```